### PR TITLE
feat: dxd11 render support

### DIFF
--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -61,8 +61,6 @@ jobs:
           git config --global --add safe.directory $PWD
 
       - uses: actions/checkout@main
-        with:
-          ref: master
 
       - name: Loading clang sysroot cache
         id: load_clang_cache
@@ -222,8 +220,6 @@ jobs:
           git config --global --add safe.directory $PWD
 
       - uses: actions/checkout@main
-        with:
-          ref: master
 
       - name: Loading release_i686 cache
         uses: actions/cache/restore@main

--- a/packages/mpv-0001-dxd11-render-api.patch
+++ b/packages/mpv-0001-dxd11-render-api.patch
@@ -1,0 +1,208 @@
+From b922ec67c730be040d737e98e66704f61e38652e Mon Sep 17 00:00:00 2001
+From: dragonflylee <dragonflylee@outlook.com>
+Date: Wed, 11 Oct 2023 21:50:13 +0800
+Subject: [PATCH] feat: add d3d11 render support
+
+---
+ include/mpv/render.h           |  6 +++
+ include/mpv/render_dxgi.h      | 18 +++++++
+ meson.build                    |  6 ++-
+ video/out/d3d11/libmpv_d3d11.c | 87 ++++++++++++++++++++++++++++++++++
+ video/out/gpu/libmpv_gpu.c     |  3 ++
+ video/out/gpu/libmpv_gpu.h     |  1 +
+ 6 files changed, 119 insertions(+), 2 deletions(-)
+ create mode 100644 include/mpv/render_dxgi.h
+ create mode 100644 video/out/d3d11/libmpv_d3d11.c
+
+diff --git a/include/mpv/render.h b/include/mpv/render.h
+index 29f9b91e9625a..d3cefdcde42c2 100644
+--- a/include/mpv/render.h
++++ b/include/mpv/render.h
+@@ -421,6 +421,10 @@ typedef enum mpv_render_param_type {
+      * See MPV_RENDER_PARAM_SW_STRIDE for alignment requirements.
+      */
+     MPV_RENDER_PARAM_SW_POINTER = 20,
++    /*
++     * MPV_RENDER_API_TYPE_DXGI only
++     */
++    MPV_RENDER_PARAM_DXGI_INIT_PARAMS = 21,
+ } mpv_render_param_type;
+ 
+ /**
+@@ -467,6 +471,8 @@ typedef struct mpv_render_param {
+ #define MPV_RENDER_API_TYPE_OPENGL "opengl"
+ // See section "Software renderer"
+ #define MPV_RENDER_API_TYPE_SW "sw"
++// See render_dxgi.h
++#define MPV_RENDER_API_TYPE_DXGI "dxgi"
+ 
+ /**
+  * Flags used in mpv_render_frame_info.flags. Each value represents a bit in it.
+diff --git a/include/mpv/render_dxgi.h b/include/mpv/render_dxgi.h
+new file mode 100644
+index 0000000000000..5614cc99d994e
+--- /dev/null
++++ b/include/mpv/render_dxgi.h
+@@ -0,0 +1,18 @@
++#ifndef MPV_CLIENT_API_RENDER_DXGI_H_
++#define MPV_CLIENT_API_RENDER_DXGI_H_
++
++#include "render.h"
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++typedef struct mpv_dxgi_init_params {
++    void *device;
++    void *swapchain;
++} mpv_dxgi_init_params;
++
++#ifdef __cplusplus
++}
++#endif
++#endif // MPV_CLIENT_API_RENDER_DXGI_H_
+diff --git a/meson.build b/meson.build
+index f9fe4e726329a..0b19fbf1c1942 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1003,7 +1003,8 @@ d3d11 = get_option('d3d11').require(
+ features += {'d3d11': d3d11.allowed()}
+ if features['d3d11']
+     sources += files('video/out/d3d11/context.c',
+-                     'video/out/d3d11/ra_d3d11.c')
++                     'video/out/d3d11/ra_d3d11.c',
++                     'video/out/d3d11/libmpv_d3d11.c')
+ endif
+ 
+ wayland = {
+@@ -1776,7 +1777,8 @@ if get_option('libmpv')
+                  description: 'mpv media player client library')
+ 
+     headers = ['include/mpv/client.h', 'include/mpv/render.h',
+-               'include/mpv/render_gl.h', 'include/mpv/stream_cb.h']
++               'include/mpv/render_gl.h', 'include/mpv/stream_cb.h',
++               'include/mpv/render_dxgi.h']
+     install_headers(headers, subdir: 'mpv')
+ 
+     # Allow projects to build with libmpv by cloning into ./subprojects/mpv
+diff --git a/video/out/d3d11/libmpv_d3d11.c b/video/out/d3d11/libmpv_d3d11.c
+new file mode 100644
+index 0000000000000..9059834745fdb
+--- /dev/null
++++ b/video/out/d3d11/libmpv_d3d11.c
+@@ -0,0 +1,87 @@
++#include "common/msg.h"
++#include "ra_d3d11.h"
++#include "mpv/render_dxgi.h"
++#include "video/out/gpu/libmpv_gpu.h"
++#include "osdep/windows_utils.h"
++
++struct priv {
++    struct ra_tex *tex;
++    ID3D11Device *device;
++    IDXGISwapChain *swapchain;
++};
++
++static int init(struct libmpv_gpu_context *ctx, mpv_render_param *params)
++{
++    MP_VERBOSE(ctx, "Creating libmpv d3d11 context\n");
++    struct priv *p = ctx->priv = talloc_zero(NULL, struct priv);
++
++    mpv_dxgi_init_params *init_params =
++        get_mpv_render_param(params, MPV_RENDER_PARAM_DXGI_INIT_PARAMS, NULL);
++    if (!init_params)
++        return MPV_ERROR_INVALID_PARAMETER;
++
++    p->device = init_params->device;
++    p->swapchain = init_params->swapchain;
++    ID3D11Device_AddRef(p->device);
++    ID3D11Device_AddRef(p->swapchain);
++
++    // initialize a blank ra_ctx to reuse ra_gl_ctx
++    struct ra_ctx *ra_ctx = talloc_zero(p, struct ra_ctx);
++    ra_ctx->log = ctx->log;
++    ra_ctx->global = ctx->global;
++
++    if (!spirv_compiler_init(ra_ctx))
++        return MPV_ERROR_UNSUPPORTED;
++
++    ra_ctx->ra = ra_d3d11_create(p->device, ctx->log, ra_ctx->spirv);
++    if (!ra_ctx->ra)
++        return MPV_ERROR_UNSUPPORTED;    
++
++    ctx->ra_ctx = ra_ctx;
++    return 0;
++}
++
++static int wrap_fbo(struct libmpv_gpu_context *ctx, mpv_render_param *params, struct ra_tex **out)
++{
++    struct priv *p = ctx->priv;
++    ID3D11Resource *backbuffer = NULL;
++
++    if (!p->tex) {
++        HRESULT hr = IDXGISwapChain_GetBuffer(p->swapchain, 0, &IID_ID3D11Texture2D,
++                        (void**)&backbuffer);
++        if (FAILED(hr)) {
++            MP_ERR(ctx, "Couldn't get swapchain image\n");
++            return MPV_ERROR_UNSUPPORTED;
++        }
++        p->tex = ra_d3d11_wrap_tex(ctx->ra_ctx->ra, backbuffer);
++        SAFE_RELEASE(backbuffer);
++    }
++
++    *out = p->tex;
++    return 0;
++}
++
++static void done_frame(struct libmpv_gpu_context *ctx, bool ds)
++{
++    struct priv *p = ctx->priv;
++
++    ra_d3d11_flush(ctx->ra_ctx->ra);
++    ra_tex_free(ctx->ra_ctx->ra, &p->tex);
++}
++
++static void destroy(struct libmpv_gpu_context *ctx)
++{
++    struct priv *p = ctx->priv;
++    if (ctx->ra_ctx->ra)
++        ra_tex_free(ctx->ra_ctx->ra, &p->tex);
++    SAFE_RELEASE(p->swapchain);
++    SAFE_RELEASE(p->device);
++}
++
++const struct libmpv_gpu_context_fns libmpv_gpu_context_d3d11 = {
++    .api_name    = MPV_RENDER_API_TYPE_DXGI,
++    .init        = init,
++    .wrap_fbo    = wrap_fbo,
++    .done_frame  = done_frame,
++    .destroy     = destroy,
++};
+\ No newline at end of file
+diff --git a/video/out/gpu/libmpv_gpu.c b/video/out/gpu/libmpv_gpu.c
+index aae1d18eed9ef..bc65a73f7b738 100644
+--- a/video/out/gpu/libmpv_gpu.c
++++ b/video/out/gpu/libmpv_gpu.c
+@@ -6,6 +6,9 @@
+ #include "video/out/libmpv.h"
+ 
+ static const struct libmpv_gpu_context_fns *context_backends[] = {
++#if HAVE_D3D11
++    &libmpv_gpu_context_d3d11,
++#endif
+ #if HAVE_GL
+     &libmpv_gpu_context_gl,
+ #endif
+diff --git a/video/out/gpu/libmpv_gpu.h b/video/out/gpu/libmpv_gpu.h
+index 497dcc3f694c8..fad1a00c0a6d9 100644
+--- a/video/out/gpu/libmpv_gpu.h
++++ b/video/out/gpu/libmpv_gpu.h
+@@ -38,3 +38,4 @@ struct libmpv_gpu_context_fns {
+ };
+ 
+ extern const struct libmpv_gpu_context_fns libmpv_gpu_context_gl;
++extern const struct libmpv_gpu_context_fns libmpv_gpu_context_d3d11;
+-- 
+2.42.0
+

--- a/packages/mpv-0001-dxd11-render-api.patch
+++ b/packages/mpv-0001-dxd11-render-api.patch
@@ -1,24 +1,24 @@
-From b922ec67c730be040d737e98e66704f61e38652e Mon Sep 17 00:00:00 2001
-From: dragonflylee <dragonflylee@outlook.com>
-Date: Wed, 11 Oct 2023 21:50:13 +0800
+From e6dd0e8720d397d89e81bbac392be683a15935e0 Mon Sep 17 00:00:00 2001
+From: Predidit <34627277+Predidit@users.noreply.github.com>
+Date: Tue, 14 Oct 2025 16:16:42 +0800
 Subject: [PATCH] feat: add d3d11 render support
 
 ---
  include/mpv/render.h           |  6 +++
  include/mpv/render_dxgi.h      | 18 +++++++
  meson.build                    |  6 ++-
- video/out/d3d11/libmpv_d3d11.c | 87 ++++++++++++++++++++++++++++++++++
+ video/out/d3d11/libmpv_d3d11.c | 96 ++++++++++++++++++++++++++++++++++
  video/out/gpu/libmpv_gpu.c     |  3 ++
  video/out/gpu/libmpv_gpu.h     |  1 +
- 6 files changed, 119 insertions(+), 2 deletions(-)
+ 6 files changed, 128 insertions(+), 2 deletions(-)
  create mode 100644 include/mpv/render_dxgi.h
  create mode 100644 video/out/d3d11/libmpv_d3d11.c
 
 diff --git a/include/mpv/render.h b/include/mpv/render.h
-index 29f9b91e9625a..d3cefdcde42c2 100644
+index 99aadeb5d8..0bb33d4e56 100644
 --- a/include/mpv/render.h
 +++ b/include/mpv/render.h
-@@ -421,6 +421,10 @@ typedef enum mpv_render_param_type {
+@@ -422,6 +422,10 @@ typedef enum mpv_render_param_type {
       * See MPV_RENDER_PARAM_SW_STRIDE for alignment requirements.
       */
      MPV_RENDER_PARAM_SW_POINTER = 20,
@@ -29,7 +29,7 @@ index 29f9b91e9625a..d3cefdcde42c2 100644
  } mpv_render_param_type;
  
  /**
-@@ -467,6 +471,8 @@ typedef struct mpv_render_param {
+@@ -468,6 +472,8 @@ typedef struct mpv_render_param {
  #define MPV_RENDER_API_TYPE_OPENGL "opengl"
  // See section "Software renderer"
  #define MPV_RENDER_API_TYPE_SW "sw"
@@ -40,7 +40,7 @@ index 29f9b91e9625a..d3cefdcde42c2 100644
   * Flags used in mpv_render_frame_info.flags. Each value represents a bit in it.
 diff --git a/include/mpv/render_dxgi.h b/include/mpv/render_dxgi.h
 new file mode 100644
-index 0000000000000..5614cc99d994e
+index 0000000000..5614cc99d9
 --- /dev/null
 +++ b/include/mpv/render_dxgi.h
 @@ -0,0 +1,18 @@
@@ -63,7 +63,7 @@ index 0000000000000..5614cc99d994e
 +#endif
 +#endif // MPV_CLIENT_API_RENDER_DXGI_H_
 diff --git a/meson.build b/meson.build
-index f9fe4e726329a..0b19fbf1c1942 100644
+index 8d43b4c84b..0889e2d13a 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1003,7 +1003,8 @@ d3d11 = get_option('d3d11').require(
@@ -76,7 +76,7 @@ index f9fe4e726329a..0b19fbf1c1942 100644
  endif
  
  wayland = {
-@@ -1776,7 +1777,8 @@ if get_option('libmpv')
+@@ -1774,7 +1775,8 @@ if get_option('libmpv')
                   description: 'mpv media player client library')
  
      headers = ['include/mpv/client.h', 'include/mpv/render.h',
@@ -88,10 +88,10 @@ index f9fe4e726329a..0b19fbf1c1942 100644
      # Allow projects to build with libmpv by cloning into ./subprojects/mpv
 diff --git a/video/out/d3d11/libmpv_d3d11.c b/video/out/d3d11/libmpv_d3d11.c
 new file mode 100644
-index 0000000000000..9059834745fdb
+index 0000000000..8b2822446e
 --- /dev/null
 +++ b/video/out/d3d11/libmpv_d3d11.c
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,96 @@
 +#include "common/msg.h"
 +#include "ra_d3d11.h"
 +#include "mpv/render_dxgi.h"
@@ -168,7 +168,6 @@ index 0000000000000..9059834745fdb
 +static void destroy(struct libmpv_gpu_context *ctx)
 +{
 +    struct priv *p = ctx->priv;
-+    
 +    if (p->ra_ctx) {
 +        if (p->ra_ctx->ra) {
 +            ra_tex_free(p->ra_ctx->ra, &p->tex);
@@ -178,7 +177,6 @@ index 0000000000000..9059834745fdb
 +            p->ra_ctx->spirv->fns->uninit(p->ra_ctx);
 +        talloc_free(p->ra_ctx);
 +    }
-+    
 +    SAFE_RELEASE(p->swapchain);
 +    SAFE_RELEASE(p->device);
 +}
@@ -190,9 +188,8 @@ index 0000000000000..9059834745fdb
 +    .done_frame  = done_frame,
 +    .destroy     = destroy,
 +};
-\ No newline at end of file
 diff --git a/video/out/gpu/libmpv_gpu.c b/video/out/gpu/libmpv_gpu.c
-index aae1d18eed9ef..bc65a73f7b738 100644
+index 1b13c79632..abeef947b6 100644
 --- a/video/out/gpu/libmpv_gpu.c
 +++ b/video/out/gpu/libmpv_gpu.c
 @@ -6,6 +6,9 @@
@@ -206,16 +203,13 @@ index aae1d18eed9ef..bc65a73f7b738 100644
      &libmpv_gpu_context_gl,
  #endif
 diff --git a/video/out/gpu/libmpv_gpu.h b/video/out/gpu/libmpv_gpu.h
-index 497dcc3f694c8..fad1a00c0a6d9 100644
+index 497dcc3f69..fad1a00c0a 100644
 --- a/video/out/gpu/libmpv_gpu.h
 +++ b/video/out/gpu/libmpv_gpu.h
-@@ -38,3 +38,7 @@ struct libmpv_gpu_context_fns {
+@@ -38,3 +38,4 @@ struct libmpv_gpu_context_fns {
  };
  
  extern const struct libmpv_gpu_context_fns libmpv_gpu_context_gl;
-+
-+#if HAVE_D3D11
 +extern const struct libmpv_gpu_context_fns libmpv_gpu_context_d3d11;
-+#endif
 -- 
-2.42.0
+2.46.0.windows.1

--- a/packages/mpv-0001-dxd11-render-api.patch
+++ b/packages/mpv-0001-dxd11-render-api.patch
@@ -174,7 +174,8 @@ index 0000000000000..9059834745fdb
 +            ra_tex_free(p->ra_ctx->ra, &p->tex);
 +            p->ra_ctx->ra->fns->destroy(p->ra_ctx->ra);
 +        }
-+        spirv_compiler_uninit(p->ra_ctx);
++        if (p->ra_ctx->spirv && p->ra_ctx->spirv->fns->uninit)
++            p->ra_ctx->spirv->fns->uninit(p->ra_ctx);
 +        talloc_free(p->ra_ctx);
 +    }
 +    

--- a/packages/mpv-0001-dxd11-render-api.patch
+++ b/packages/mpv-0001-dxd11-render-api.patch
@@ -209,11 +209,13 @@ diff --git a/video/out/gpu/libmpv_gpu.h b/video/out/gpu/libmpv_gpu.h
 index 497dcc3f694c8..fad1a00c0a6d9 100644
 --- a/video/out/gpu/libmpv_gpu.h
 +++ b/video/out/gpu/libmpv_gpu.h
-@@ -38,3 +38,4 @@ struct libmpv_gpu_context_fns {
+@@ -38,3 +38,7 @@ struct libmpv_gpu_context_fns {
  };
  
  extern const struct libmpv_gpu_context_fns libmpv_gpu_context_gl;
++
++#if HAVE_D3D11
 +extern const struct libmpv_gpu_context_fns libmpv_gpu_context_d3d11;
++#endif
 -- 
 2.42.0
-

--- a/packages/mpv-0001-dxd11-render-api.patch
+++ b/packages/mpv-0001-dxd11-render-api.patch
@@ -99,6 +99,7 @@ index 0000000000000..9059834745fdb
 +#include "osdep/windows_utils.h"
 +
 +struct priv {
++    struct ra_ctx *ra_ctx;
 +    struct ra_tex *tex;
 +    ID3D11Device *device;
 +    IDXGISwapChain *swapchain;
@@ -107,7 +108,8 @@ index 0000000000000..9059834745fdb
 +static int init(struct libmpv_gpu_context *ctx, mpv_render_param *params)
 +{
 +    MP_VERBOSE(ctx, "Creating libmpv d3d11 context\n");
-+    struct priv *p = ctx->priv = talloc_zero(NULL, struct priv);
++    ctx->priv = talloc_zero(NULL, struct priv);
++    struct priv *p = ctx->priv;
 +
 +    mpv_dxgi_init_params *init_params =
 +        get_mpv_render_param(params, MPV_RENDER_PARAM_DXGI_INIT_PARAMS, NULL);
@@ -117,21 +119,21 @@ index 0000000000000..9059834745fdb
 +    p->device = init_params->device;
 +    p->swapchain = init_params->swapchain;
 +    ID3D11Device_AddRef(p->device);
-+    ID3D11Device_AddRef(p->swapchain);
++    IDXGISwapChain_AddRef(p->swapchain);
 +
 +    // initialize a blank ra_ctx to reuse ra_gl_ctx
-+    struct ra_ctx *ra_ctx = talloc_zero(p, struct ra_ctx);
-+    ra_ctx->log = ctx->log;
-+    ra_ctx->global = ctx->global;
++    p->ra_ctx = talloc_zero(p, struct ra_ctx);
++    p->ra_ctx->log = ctx->log;
++    p->ra_ctx->global = ctx->global;
 +
-+    if (!spirv_compiler_init(ra_ctx))
++    if (!spirv_compiler_init(p->ra_ctx))
 +        return MPV_ERROR_UNSUPPORTED;
 +
-+    ra_ctx->ra = ra_d3d11_create(p->device, ctx->log, ra_ctx->spirv);
-+    if (!ra_ctx->ra)
++    p->ra_ctx->ra = ra_d3d11_create(p->device, ctx->log, p->ra_ctx->spirv);
++    if (!p->ra_ctx->ra)
 +        return MPV_ERROR_UNSUPPORTED;    
 +
-+    ctx->ra_ctx = ra_ctx;
++    ctx->ra_ctx = p->ra_ctx;
 +    return 0;
 +}
 +
@@ -147,7 +149,7 @@ index 0000000000000..9059834745fdb
 +            MP_ERR(ctx, "Couldn't get swapchain image\n");
 +            return MPV_ERROR_UNSUPPORTED;
 +        }
-+        p->tex = ra_d3d11_wrap_tex(ctx->ra_ctx->ra, backbuffer);
++        p->tex = ra_d3d11_wrap_tex(p->ra_ctx->ra, backbuffer);
 +        SAFE_RELEASE(backbuffer);
 +    }
 +
@@ -159,15 +161,23 @@ index 0000000000000..9059834745fdb
 +{
 +    struct priv *p = ctx->priv;
 +
-+    ra_d3d11_flush(ctx->ra_ctx->ra);
-+    ra_tex_free(ctx->ra_ctx->ra, &p->tex);
++    ra_d3d11_flush(p->ra_ctx->ra);
++    ra_tex_free(p->ra_ctx->ra, &p->tex);
 +}
 +
 +static void destroy(struct libmpv_gpu_context *ctx)
 +{
 +    struct priv *p = ctx->priv;
-+    if (ctx->ra_ctx->ra)
-+        ra_tex_free(ctx->ra_ctx->ra, &p->tex);
++    
++    if (p->ra_ctx) {
++        if (p->ra_ctx->ra) {
++            ra_tex_free(p->ra_ctx->ra, &p->tex);
++            p->ra_ctx->ra->fns->destroy(p->ra_ctx->ra);
++        }
++        spirv_compiler_uninit(p->ra_ctx);
++        talloc_free(p->ra_ctx);
++    }
++    
 +    SAFE_RELEASE(p->swapchain);
 +    SAFE_RELEASE(p->device);
 +}

--- a/packages/mpv-0001-dxd11-render-api.patch
+++ b/packages/mpv-0001-dxd11-render-api.patch
@@ -91,7 +91,7 @@ new file mode 100644
 index 0000000000000..9059834745fdb
 --- /dev/null
 +++ b/video/out/d3d11/libmpv_d3d11.c
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,90 @@
 +#include "common/msg.h"
 +#include "ra_d3d11.h"
 +#include "mpv/render_dxgi.h"

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -32,7 +32,6 @@ ExternalProject_Add(mpv-release
         spirv-cross
     URL ${LINK}
     SOURCE_DIR ${SOURCE_LOCATION}
-    PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
     CONFIGURE_COMMAND ${EXEC} CONF=1 meson setup <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
         --libdir=${MINGW_INSTALL_PREFIX}/lib

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -32,6 +32,7 @@ ExternalProject_Add(mpv-release
         spirv-cross
     URL ${LINK}
     SOURCE_DIR ${SOURCE_LOCATION}
+    PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
     CONFIGURE_COMMAND ${EXEC} CONF=1 meson setup <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
         --libdir=${MINGW_INSTALL_PREFIX}/lib

--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -17,6 +17,7 @@ ExternalProject_Add(mpv
         spirv-cross
     GIT_REPOSITORY https://github.com/mpv-player/mpv.git
     SOURCE_DIR ${SOURCE_LOCATION}
+    PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ${EXEC} CONF=1 meson setup <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
@@ -66,6 +67,7 @@ ExternalProject_Add_Step(mpv copy-binary
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/include/mpv/stream_cb.h    ${CMAKE_CURRENT_BINARY_DIR}/mpv-dev/include/mpv/stream_cb.h
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/include/mpv/render.h       ${CMAKE_CURRENT_BINARY_DIR}/mpv-dev/include/mpv/render.h
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/include/mpv/render_gl.h    ${CMAKE_CURRENT_BINARY_DIR}/mpv-dev/include/mpv/render_gl.h
+    COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/include/mpv/render_dxgi.h  ${CMAKE_CURRENT_BINARY_DIR}/mpv-dev/include/mpv/render_dxgi.h
     COMMENT "Copying mpv binaries and manual"
 )
 

--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -18,8 +18,8 @@ ExternalProject_Add(mpv
     GIT_REPOSITORY https://github.com/mpv-player/mpv.git
     GIT_TAG ad59ff1b4a7479e15cb01a96f64ada4fb4df4951
     SOURCE_DIR ${SOURCE_LOCATION}
-    UPDATE_COMMAND ""
     PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
+    UPDATE_COMMAND ""
     CONFIGURE_COMMAND ${EXEC} CONF=1 meson setup <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
         --libdir=${MINGW_INSTALL_PREFIX}/lib

--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -16,6 +16,7 @@ ExternalProject_Add(mpv
         libplacebo
         spirv-cross
     GIT_REPOSITORY https://github.com/mpv-player/mpv.git
+    GIT_TAG ad59ff1b4a7479e15cb01a96f64ada4fb4df4951
     SOURCE_DIR ${SOURCE_LOCATION}
     PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
     UPDATE_COMMAND ""

--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -18,8 +18,8 @@ ExternalProject_Add(mpv
     GIT_REPOSITORY https://github.com/mpv-player/mpv.git
     GIT_TAG ad59ff1b4a7479e15cb01a96f64ada4fb4df4951
     SOURCE_DIR ${SOURCE_LOCATION}
-    PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
     UPDATE_COMMAND ""
+    PATCH_COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/mpv-*.patch
     CONFIGURE_COMMAND ${EXEC} CONF=1 meson setup <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
         --libdir=${MINGW_INSTALL_PREFIX}/lib


### PR DESCRIPTION
The out-of-tree patch in this PR is not a verbatim copy of [PR 12627](https://patch-diff.githubusercontent.com/raw/mpv-player/mpv/pull/12627.patch). In addition to rebasing onto the current mpv master branch, I fixed an issue where the original PR did not handle `ra_ctx` correctly, which caused a severe memory leak (around 100 MB per player instance). I’m not an mpv expert and only applied a minimal fix. If possible, please review this patch to ensure there aren’t any other issues.